### PR TITLE
Add Meta's AITemplate and nebullvm to the list of AI Chip Compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,8 @@ The SimpleMachines, Inc. (SMI) team – which includes leading research scientis
 12. <a href="https://www.polymagelabs.com//">PolyMage Labs</a><br>
 13. <a href="https://octoml.ai/">OctoML</a><br>
 14. <a href="https://www.modular.com/">Modular AI</a><br>
+15. <a href="https://github.com/facebookincubator/AITemplate">AITemplate</a><br>
+16. <a href="https://github.com/nebuly-ai/nebullvm">nebullvm</a><br>
 
 <div align="center"><h3> </h3></div>
 


### PR DESCRIPTION
Hi, 
I have added two projects to the list of AI Chip Compilers.
AITemplate was launched yesterday by Meta and seems very promising. It should be/become an alternative to Apache TVM or tensorRT. And nebullvm is a tool to automatically test various AI compilers as well as pruning and quantization techniques to identify what is the best performance for the user's model/hardware. 

